### PR TITLE
Add const qualifiers to read-only address parameters

### DIFF
--- a/natcap_client.c
+++ b/natcap_client.c
@@ -4866,7 +4866,7 @@ void cn_domain_clean(void)
 	}
 }
 
-void domain_copy(char *dst, char *from)
+void domain_copy(char *dst, const char *from)
 {
 	int s = 0;
 	int len = strlen(from);
@@ -4881,7 +4881,7 @@ void domain_copy(char *dst, char *from)
 	}
 }
 
-int domain_cmp(char *dst, char *src)
+int domain_cmp(const char *dst, const char *src)
 {
 	int i;
 	int len = strlen(src);
@@ -4919,7 +4919,7 @@ int domain_cmp(char *dst, char *src)
 	return 1;
 }
 
-int cn_domain_insert(char *d)
+int cn_domain_insert(const char *d)
 {
 	int low;
 	int high;
@@ -4982,7 +4982,7 @@ int cn_domain_insert(char *d)
 	return 0;
 }
 
-int domain_match(char *dst, char *src)
+int domain_match(const char *dst, const char *src)
 {
 	int i;
 	int len = strlen(src);
@@ -5026,7 +5026,7 @@ int domain_match(char *dst, char *src)
 	return 1;
 }
 
-int cn_domain_lookup(char *d)
+int cn_domain_lookup(const char *d)
 {
 	int low;
 	int high;
@@ -5056,7 +5056,7 @@ int cn_domain_lookup(char *d)
 	return 0;
 }
 
-int cn_domain_load_from_path(char *path)
+int cn_domain_load_from_path(const char *path)
 {
 	loff_t pos = 0;
 	ssize_t bytes = 0;
@@ -5110,7 +5110,7 @@ int cn_domain_load_from_path(char *path)
 	return 0;
 }
 
-int cn_domain_load_from_raw(char *path)
+int cn_domain_load_from_raw(const char *path)
 {
 	int ret = -1;
 	loff_t pos = 0;
@@ -5168,7 +5168,7 @@ out:
 	return 0;
 }
 
-int cn_domain_dump_path(char *path)
+int cn_domain_dump_path(const char *path)
 {
 	loff_t pos = 0;
 	ssize_t bytes = 0;

--- a/natcap_client.h
+++ b/natcap_client.h
@@ -136,13 +136,13 @@ static inline int get_rdata(const unsigned char *src_ptr, int src_len, int src_p
 }
 
 extern void cn_domain_clean(void);
-extern void domain_copy(char *dst, char *from);
-extern int domain_cmp(char *dst, char *src);
-extern int cn_domain_insert(char *d);
-extern int domain_match(char *dst, char *src);
-extern int cn_domain_lookup(char *d);
-extern int cn_domain_load_from_path(char *path);
-extern int cn_domain_load_from_raw(char *path);
-extern int cn_domain_dump_path(char *path);
+extern void domain_copy(char *dst, const char *from);
+extern int domain_cmp(const char *dst, const char *src);
+extern int cn_domain_insert(const char *d);
+extern int domain_match(const char *dst, const char *src);
+extern int cn_domain_lookup(const char *d);
+extern int cn_domain_load_from_path(const char *path);
+extern int cn_domain_load_from_raw(const char *path);
+extern int cn_domain_dump_path(const char *path);
 
 #endif /* _NATCAP_CLIENT_H_ */

--- a/natcap_peer.c
+++ b/natcap_peer.c
@@ -1377,7 +1377,7 @@ static inline void natcap_auth_user_confirm(const unsigned char *client_mac, int
 	skb_nfct_reset(uskb);
 }
 
-static inline void natcap_auth_reply(const struct net_device *dev, struct sk_buff *oskb, int pt_mode, unsigned char *client_mac, int auth)
+static inline void natcap_auth_reply(const struct net_device *dev, struct sk_buff *oskb, int pt_mode, const unsigned char *client_mac, int auth)
 {
 	struct sk_buff *nskb;
 	struct ethhdr *neth, *oeth;
@@ -1470,7 +1470,7 @@ static inline void natcap_auth_reply(const struct net_device *dev, struct sk_buf
 	dev_queue_xmit(nskb);
 }
 
-static inline void natcap_peer_echo_request(const struct net_device *dev, struct sk_buff *oskb, unsigned char *client_mac)
+static inline void natcap_peer_echo_request(const struct net_device *dev, struct sk_buff *oskb, const unsigned char *client_mac)
 {
 	struct sk_buff *nskb;
 	struct ethhdr *neth, *oeth;

--- a/natcap_server.c
+++ b/natcap_server.c
@@ -41,7 +41,7 @@
 unsigned int server_flow_stop = 0;
 unsigned int user_mark_natcap_mask = 0x00000000;
 #define user_mark_natcap_set(mark, at) *(unsigned int *)(at) = ((*(unsigned int *)(at)) & (~user_mark_natcap_mask)) | ((mark) & user_mark_natcap_mask)
-static inline int user_mark_natcap_get(unsigned int *at)
+static inline int user_mark_natcap_get(const unsigned int *at)
 {
 	unsigned int idx;
 	unsigned int val;


### PR DESCRIPTION
### Motivation
- Improve const-correctness by marking pointer parameters that are only read as `const`, clarifying intent and enabling safer use of these APIs. 
- Target functions that take domain/path or address buffers and do not modify the pointed-to data.

### Description
- Updated client domain helper declarations in `natcap_client.h` to take `const` for source/path parameters and updated their definitions in `natcap_client.c` accordingly (`domain_copy`, `domain_cmp`, `cn_domain_insert`, `domain_match`, `cn_domain_lookup`, `cn_domain_load_from_path`, `cn_domain_load_from_raw`, `cn_domain_dump_path`).
- Marked MAC/address input parameters as `const unsigned char *` in `natcap_peer.c` for `natcap_auth_reply` and `natcap_peer_echo_request` helper functions.
- Made `user_mark_natcap_get` accept a `const unsigned int *` in `natcap_server.c` because it only reads the pointed value.
- Changes were applied across 4 files with small, local signature updates and matching definition edits.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a468ed8cc832fbcbadce32c9e44c5)